### PR TITLE
Remove lexical-let

### DIFF
--- a/polybar-clj.el
+++ b/polybar-clj.el
@@ -226,11 +226,10 @@ as the name of the sesman project root directory."
 FN is the unwrapped `nrepl-send-request` function.  \
 REQUEST CALLBACK CONNECTION-BUFFER and TOOLING have the same \
 meaning as `nrepl-send-request`."
-  (lexical-let ((callback-fn callback)
-                (conn (polybar-clj--connection-buffer->connection connection-buffer)))
+  (let ((conn (polybar-clj--connection-buffer->connection connection-buffer)))
     (polybar-clj-start-spinner conn)
     (funcall fn request (lambda (response)
-                          (funcall callback-fn response)
+                          (funcall callback response)
                           (polybar-clj-stop-spinner conn))
              connection-buffer
              tooling)))


### PR DESCRIPTION
It is not necessary if lexical-binding is enabled.

### Reference

- https://www.gnu.org/software/emacs/manual/html_node/cl/Obsolete-Lexical-Binding.html

And fix some byte-compile warnings

```
polybar-clj.el:224:1:Warning: Unused lexical argument ‘callback’

In polybar-clj--around-advice--nrepl-send-request:
polybar-clj.el:224:104:Warning: ‘(callback-fn callback)’ is a malformed
    function
polybar-clj.el:234:53:Warning: reference to free variable ‘conn’
polybar-clj.el:233:36:Warning: reference to free variable ‘callback-fn’

In end of data:
polybar-clj.el:312:1:Warning: the following functions are not known to be defined: lexical-let,
    conn
```